### PR TITLE
Small change to raw.rs in core to allow compilation on Raspberry Pi (and possibly other ARM processors)

### DIFF
--- a/crates/core/src/raw.rs
+++ b/crates/core/src/raw.rs
@@ -415,7 +415,7 @@ impl RawTag {
             ffi::plc_tag_get_string(
                 self.tag_id,
                 byte_offset as i32,
-                buf.as_mut_ptr() as *mut i8,
+                buf.as_mut_ptr() as *mut ::std::os::raw::c_char,
                 buf.len() as i32,
             )
         };


### PR DESCRIPTION
Apparently on the Raspberry pi (I think it's a 3B that I have) std::os::raw::c_char which is used by bindgen when generating the ffi functions is a u8.  Because of this the buf.as_mut_ptr() as *mut i8 in the get_string function wouldn't compile on the raspberry pi. This simple change allows it to compile.