### PR TITLE
sys: copy files only if needed

### DIFF
--- a/crates/sys/build.rs
+++ b/crates/sys/build.rs
@@ -137,10 +137,9 @@ fn check_static() -> bool {
 }
 
 fn get_env_bool(key: &str) -> Option<bool> {
-    env::var(key).ok().map(|v| {
-        let v = v.to_lowercase();
-        v == "1" || v == "true" || v == "on" || v == "yes"
-    })
+    env::var(key)
+        .ok()
+        .map(|v| matches!(v.to_lowercase().as_ref(), "1" | "true" | "on" | "yes"))
 }
 
 fn is_file_newer(a: &Path, b: &Path) -> bool {

--- a/crates/sys/build.rs
+++ b/crates/sys/build.rs
@@ -18,7 +18,12 @@ use std::{
 use std::{ffi::OsStr, path::Component};
 
 fn main() {
-    let is_static = check_static();
+    // check if static build in the order of:
+    // PLCTAG_STATIC, PLCTAG_DYNAMIC, rustflags: +crt-static
+    let is_static = get_env_bool("LIBPLCTAG_STATIC").unwrap_or(false)
+        || get_env_bool("LIBPLCTAG_DYNAMIC").map_or(false, |v| !v)
+        || cfg!(target_feature = "crt-static");
+
     if is_static {
         eprintln!("static build");
     }
@@ -122,18 +127,6 @@ fn find_target_profile_dir<'a>(dir: impl AsRef<Path> + 'a) -> Option<PathBuf> {
             return None;
         }
     }
-}
-
-/// check if static build in the order of:
-/// PLCTAG_STATIC, PLCTAG_DYNAMIC, rustflags: +crt-static
-fn check_static() -> bool {
-    if let Some(v) = get_env_bool("LIBPLCTAG_STATIC") {
-        return v;
-    }
-    if let Some(v) = get_env_bool("LIBPLCTAG_DYNAMIC") {
-        return !v;
-    }
-    cfg!(target_feature = "crt-static")
 }
 
 fn get_env_bool(key: &str) -> Option<bool> {

--- a/crates/sys/build.rs
+++ b/crates/sys/build.rs
@@ -9,11 +9,13 @@ extern crate cmake;
 extern crate pkg_config;
 
 use std::{
-    env,
-    ffi::OsStr,
-    fs, io,
-    path::{Component, Path, PathBuf},
+    env, fs, io,
+    path::{Path, PathBuf},
+    time::SystemTime,
 };
+
+#[cfg(target_os = "windows")]
+use std::{ffi::OsStr, path::Component};
 
 fn main() {
     let is_static = check_static();
@@ -103,6 +105,7 @@ fn install_lib_files(lib_path: impl AsRef<Path>, out_path: impl AsRef<Path>) {
     }
 }
 
+#[cfg(target_os = "windows")]
 fn find_target_profile_dir<'a>(dir: impl AsRef<Path> + 'a) -> Option<PathBuf> {
     //out dir looks like ...\plctag-rs\target\debug\build\XXXXX
     //profile dir looks like ...\plctag-rs\target\debug\


### PR DESCRIPTION
The cmake build takes care of creating a build dir somewhere in OUT_DIR, so there shouldn't be any need to copy all the sources by hand. This also fixes a problem where Cargo always rebuilds the -sys crate, because the file copies essentially amount to a "touch" on all the files copied to OUT_DIR.