### PR TITLE
prevent aborting on each read/write when completes successfully

### DIFF
--- a/crates/async/src/entry.rs
+++ b/crates/async/src/entry.rs
@@ -220,8 +220,8 @@ impl AsyncTag {
         // pending
         let status = self.recv_event(event).await;
         debug_assert!(!status.is_pending());
+        guard.pending = false;
         if status.is_err() {
-            guard.pending = false;
             return Err(status.into());
         }
         drop(guard);

--- a/crates/async/src/entry.rs
+++ b/crates/async/src/entry.rs
@@ -400,7 +400,10 @@ impl InflightGuard<'_> {
                 self.pending = false;
                 Err(status.into())
             }
-            _ => unreachable!(),
+            Status::Ok => {
+                self.pending = false;
+                Ok(())
+            }
         }
     }
 
@@ -416,7 +419,10 @@ impl InflightGuard<'_> {
                 self.pending = false;
                 Err(status.into())
             }
-            _ => unreachable!(),
+            Status::Ok => {
+                self.pending = false;
+                Ok(())
+            }
         }
     }
 }

--- a/crates/async/src/entry.rs
+++ b/crates/async/src/entry.rs
@@ -217,12 +217,14 @@ impl AsyncTag {
             _ => unreachable!(),
         }
 
-        // pending
-        let status = self.recv_event(event).await;
-        debug_assert!(!status.is_pending());
-        guard.pending = false;
-        if status.is_err() {
-            return Err(status.into());
+        // Only wait for event if operation is still pending
+        if guard.pending {
+            let status = self.recv_event(event).await;
+            debug_assert!(!status.is_pending());
+            guard.pending = false;
+            if status.is_err() {
+                return Err(status.into());
+            }
         }
         drop(guard);
         Ok(())


### PR DESCRIPTION
Using this wrapper with libplctag newer than 2.6.3 is buggy. I know version 0.4.1 is supposed to be used with libplctag 2.6.3, but probably fixing this will make it work with last libplctag versions.

I've uploaded a [repo](https://github.com/n3-ruben-sanchez/plctag-rs-ub) to reproduce the issue.
It's not deterministic. Can end successfully or hang-up forever.

It's failing due to this change in [lib.c](https://github.com/libplctag/libplctag/blob/deccfa32f4eefec1918b1ece6d26c38a4d4b41fc/src/libplctag/lib/lib.c#L266).

```diff
@@ -273,22 +262,39 @@ int plc_tag_generic_wake_tag_impl(const char *func, int line_num, plc_tag_p tag)
  * automatic tag operations and callbacks.
  */

-void plc_tag_generic_tickler(plc_tag_p tag)
-{
+void plc_tag_generic_tickler(plc_tag_p tag) {
     if(tag) {
         debug_set_tag_id(tag->tag_id);

         pdebug(DEBUG_DETAIL, "Tickling tag %d.", tag->tag_id);

+        /* first check for aborts */
+        if(atomic_get_bool(&tag->abort_requested)) {
+            if(tag->vtable && tag->vtable->abort) { tag->vtable->abort(tag); }
+
+            pdebug(DEBUG_DETAIL, "Aborting ongoing operation if any!");
+
+            tag->read_complete = 0;
+            tag->read_in_flight = 0;
+            tag->write_complete = 0;
+            tag->write_in_flight = 0;
+
+            /* clear the flag so we do not do this again. */
+            atomic_set_bool(&tag->abort_requested, false);
+
+            tag_raise_event(tag, PLCTAG_EVENT_ABORTED, PLCTAG_ERR_ABORT);
+
+            /* do not do anything else. */
+            return;
+        }
+
         /* if this tag has automatic writes, then there are many things we should check */
         if(tag->auto_sync_write_ms > 0) {
             /* has the tag been written to? */
             if(tag->tag_is_dirty) {
                 /* abort any in flight read if the tag is dirty. */
                 if(tag->read_in_flight) {
-                    if(tag->vtable && tag->vtable->abort) {
-                        tag->vtable->abort(tag);
-                    }
+                    if(tag->vtable && tag->vtable->abort) { tag->vtable->abort(tag); }

                     pdebug(DEBUG_DETAIL, "Aborting in-flight automatic read!");
```

So now, due to the abort on Drop when is pending (always unless error status return), libplctag is triggering abort procedure and raising abort event. Code works properly if PLCTAG_EVENT_READ_COMPLETED or PLCTAG_EVENT_WRITE_COMPLETED is raised first, and hangs up if it's PLCTAG_EVENT_ABORTED.

Despite of this, personally doesn't make sense to keep guard.pending as true if status is different from ```Status::Pending``` variant.